### PR TITLE
Fix wrong datasets url

### DIFF
--- a/hooks/useQuery.ts
+++ b/hooks/useQuery.ts
@@ -17,7 +17,7 @@ export function useQuery(cp: string, fuel: string) {
     useEffect(() => {
         // to get only fuel price on request
         const fuelName = fuel.toLowerCase();
-        const encodedUri = encodeURI(`https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/prix-des-carburants-en-france-flux-instantane-v2/records?select=adresse,${fuelName}_prix AS prix,id&where=cp like "${cp}" and carburants_disponibles in ("${fuel}")&limit=-1`)
+        const encodedUri = encodeURI(`https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/prix-carburants-flux-instantane-v2/records?select=adresse,${fuelName}_prix AS prix,id&where=cp like "${cp}" and carburants_disponibles in ("${fuel}")&limit=-1`)
         setIsLoading(true);
         fetch(encodedUri)
             .then((r) => {


### PR DESCRIPTION
Since 9 april 2024, the datasets name has been renamed to `prix-carburants-flux-instantane-v2` (previously, it was `prix-des-carburants-en-france-flux-instantane-v2`).